### PR TITLE
Updated js switch statement to include default

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1080,6 +1080,7 @@ function pickupToString(date) {
     switch (skin) {
         case 'weborder':
         case 'weborder_mobile':
+        default:
             result = d.toString().replace(/([a-z]+) ([a-z]+) (\d{1,2}) .+/i,'$2 $3, ').concat(time.toString());
     }
 


### PR DESCRIPTION
We ran into a date formatting issue on a site that uses a custom skin.

Originally, this function would only work if you're using the "weborder" or "weborder_mobile" skins, but adding a default to this switch resolves the issue.